### PR TITLE
Add global scraping lock to prevent concurrent job scraping

### DIFF
--- a/upwork-job-scraper/background.js
+++ b/upwork-job-scraper/background.js
@@ -42,6 +42,9 @@ try {
   let lastInitializationTime = 0;
   const MIN_INITIALIZATION_INTERVAL = 5000; // 5 seconds minimum between initializations
 
+  // Add global lock for job scraping
+  let isScrapingInProgress = false;
+
   // Initialize settings when extension starts
   chrome.storage.sync.get(
     ["jobScrapingEnabled", "checkFrequency", "schedule"],


### PR DESCRIPTION
- Implement a global lock mechanism in background.js to prevent multiple simultaneous job scraping attempts
- Modify jobScraping.js to check and respect the global scraping lock
- Ensure only one job scraping operation can run at a time
- Add logging for skipped scraping attempts when lock is active