### PR TITLE
Centralize versioning in app-v3

### DIFF
--- a/.agents/skills/changelog-automation/SKILL.md
+++ b/.agents/skills/changelog-automation/SKILL.md
@@ -1,0 +1,580 @@
+---
+name: changelog-automation
+description: Automate changelog generation from commits, PRs, and releases following Keep a Changelog format. Use when setting up release workflows, generating release notes, or standardizing commit conventions.
+---
+
+# Changelog Automation
+
+Patterns and tools for automating changelog generation, release notes, and version management following industry standards.
+
+## When to Use This Skill
+
+- Setting up automated changelog generation
+- Implementing Conventional Commits
+- Creating release note workflows
+- Standardizing commit message formats
+- Generating GitHub/GitLab release notes
+- Managing semantic versioning
+
+## Core Concepts
+
+### 1. Keep a Changelog Format
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- New feature X
+
+## [1.2.0] - 2024-01-15
+
+### Added
+
+- User profile avatars
+- Dark mode support
+
+### Changed
+
+- Improved loading performance by 40%
+
+### Deprecated
+
+- Old authentication API (use v2)
+
+### Removed
+
+- Legacy payment gateway
+
+### Fixed
+
+- Login timeout issue (#123)
+
+### Security
+
+- Updated dependencies for CVE-2024-1234
+
+[Unreleased]: https://github.com/user/repo/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/user/repo/compare/v1.1.0...v1.2.0
+```
+
+### 2. Conventional Commits
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+| Type       | Description      | Changelog Section  |
+| ---------- | ---------------- | ------------------ |
+| `feat`     | New feature      | Added              |
+| `fix`      | Bug fix          | Fixed              |
+| `docs`     | Documentation    | (usually excluded) |
+| `style`    | Formatting       | (usually excluded) |
+| `refactor` | Code restructure | Changed            |
+| `perf`     | Performance      | Changed            |
+| `test`     | Tests            | (usually excluded) |
+| `chore`    | Maintenance      | (usually excluded) |
+| `ci`       | CI changes       | (usually excluded) |
+| `build`    | Build system     | (usually excluded) |
+| `revert`   | Revert commit    | Removed            |
+
+### 3. Semantic Versioning
+
+```
+MAJOR.MINOR.PATCH
+
+MAJOR: Breaking changes (feat! or BREAKING CHANGE)
+MINOR: New features (feat)
+PATCH: Bug fixes (fix)
+```
+
+## Implementation
+
+### Method 1: Conventional Changelog (Node.js)
+
+```bash
+# Install tools
+npm install -D @commitlint/cli @commitlint/config-conventional
+npm install -D husky
+npm install -D standard-version
+# or
+npm install -D semantic-release
+
+# Setup commitlint
+cat > commitlint.config.js << 'EOF'
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'type-enum': [
+      2,
+      'always',
+      [
+        'feat',
+        'fix',
+        'docs',
+        'style',
+        'refactor',
+        'perf',
+        'test',
+        'chore',
+        'ci',
+        'build',
+        'revert',
+      ],
+    ],
+    'subject-case': [2, 'never', ['start-case', 'pascal-case', 'upper-case']],
+    'subject-max-length': [2, 'always', 72],
+  },
+};
+EOF
+
+# Setup husky
+npx husky init
+echo "npx --no -- commitlint --edit \$1" > .husky/commit-msg
+```
+
+### Method 2: standard-version Configuration
+
+```javascript
+// .versionrc.js
+module.exports = {
+  types: [
+    { type: "feat", section: "Features" },
+    { type: "fix", section: "Bug Fixes" },
+    { type: "perf", section: "Performance Improvements" },
+    { type: "revert", section: "Reverts" },
+    { type: "docs", section: "Documentation", hidden: true },
+    { type: "style", section: "Styles", hidden: true },
+    { type: "chore", section: "Miscellaneous", hidden: true },
+    { type: "refactor", section: "Code Refactoring", hidden: true },
+    { type: "test", section: "Tests", hidden: true },
+    { type: "build", section: "Build System", hidden: true },
+    { type: "ci", section: "CI/CD", hidden: true },
+  ],
+  commitUrlFormat: "{{host}}/{{owner}}/{{repository}}/commit/{{hash}}",
+  compareUrlFormat:
+    "{{host}}/{{owner}}/{{repository}}/compare/{{previousTag}}...{{currentTag}}",
+  issueUrlFormat: "{{host}}/{{owner}}/{{repository}}/issues/{{id}}",
+  userUrlFormat: "{{host}}/{{user}}",
+  releaseCommitMessageFormat: "chore(release): {{currentTag}}",
+  scripts: {
+    prebump: 'echo "Running prebump"',
+    postbump: 'echo "Running postbump"',
+    prechangelog: 'echo "Running prechangelog"',
+    postchangelog: 'echo "Running postchangelog"',
+  },
+};
+```
+
+```json
+// package.json scripts
+{
+  "scripts": {
+    "release": "standard-version",
+    "release:minor": "standard-version --release-as minor",
+    "release:major": "standard-version --release-as major",
+    "release:patch": "standard-version --release-as patch",
+    "release:dry": "standard-version --dry-run"
+  }
+}
+```
+
+### Method 3: semantic-release (Full Automation)
+
+```javascript
+// release.config.js
+module.exports = {
+  branches: [
+    "main",
+    { name: "beta", prerelease: true },
+    { name: "alpha", prerelease: true },
+  ],
+  plugins: [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/changelog",
+      {
+        changelogFile: "CHANGELOG.md",
+      },
+    ],
+    [
+      "@semantic-release/npm",
+      {
+        npmPublish: true,
+      },
+    ],
+    [
+      "@semantic-release/github",
+      {
+        assets: ["dist/**/*.js", "dist/**/*.css"],
+      },
+    ],
+    [
+      "@semantic-release/git",
+      {
+        assets: ["CHANGELOG.md", "package.json"],
+        message:
+          "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
+      },
+    ],
+  ],
+};
+```
+
+### Method 4: GitHub Actions Workflow
+
+```yaml
+# .github/workflows/release.yml
+name: Release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: "Release type"
+        required: true
+        default: "patch"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - run: npm ci
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Run semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npx semantic-release
+
+  # Alternative: manual release with standard-version
+  manual-release:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - run: npm ci
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version and generate changelog
+        run: npx standard-version --release-as ${{ inputs.release_type }}
+
+      - name: Push changes
+        run: git push --follow-tags origin main
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          body_path: RELEASE_NOTES.md
+          generate_release_notes: true
+```
+
+### Method 5: git-cliff (Rust-based, Fast)
+
+```toml
+# cliff.toml
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+"""
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.scope %}**{{ commit.scope }}:** {% endif %}\
+            {{ commit.message | upper_first }}\
+            {% if commit.github.pr_number %} ([#{{ commit.github.pr_number }}](https://github.com/owner/repo/pull/{{ commit.github.pr_number }})){% endif %}\
+    {% endfor %}
+{% endfor %}
+"""
+footer = """
+{% for release in releases -%}
+    {% if release.version -%}
+        {% if release.previous.version -%}
+            [{{ release.version | trim_start_matches(pat="v") }}]: \
+                https://github.com/owner/repo/compare/{{ release.previous.version }}...{{ release.version }}
+        {% endif -%}
+    {% else -%}
+        [unreleased]: https://github.com/owner/repo/compare/{{ release.previous.version }}...HEAD
+    {% endif -%}
+{% endfor %}
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^doc", group = "Documentation" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactoring" },
+    { message = "^style", group = "Styling" },
+    { message = "^test", group = "Testing" },
+    { message = "^chore\\(release\\)", skip = true },
+    { message = "^chore", group = "Miscellaneous" },
+]
+filter_commits = false
+tag_pattern = "v[0-9]*"
+skip_tags = ""
+ignore_tags = ""
+topo_order = false
+sort_commits = "oldest"
+
+[github]
+owner = "owner"
+repo = "repo"
+```
+
+```bash
+# Generate changelog
+git cliff -o CHANGELOG.md
+
+# Generate for specific range
+git cliff v1.0.0..v2.0.0 -o RELEASE_NOTES.md
+
+# Preview without writing
+git cliff --unreleased --dry-run
+```
+
+### Method 6: Python (commitizen)
+
+```toml
+# pyproject.toml
+[tool.commitizen]
+name = "cz_conventional_commits"
+version = "1.0.0"
+version_files = [
+    "pyproject.toml:version",
+    "src/__init__.py:__version__",
+]
+tag_format = "v$version"
+update_changelog_on_bump = true
+changelog_incremental = true
+changelog_start_rev = "v0.1.0"
+
+[tool.commitizen.customize]
+message_template = "{{change_type}}{% if scope %}({{scope}}){% endif %}: {{message}}"
+schema = "<type>(<scope>): <subject>"
+schema_pattern = "^(feat|fix|docs|style|refactor|perf|test|chore)(\\(\\w+\\))?:\\s.*"
+bump_pattern = "^(feat|fix|perf|refactor)"
+bump_map = {"feat" = "MINOR", "fix" = "PATCH", "perf" = "PATCH", "refactor" = "PATCH"}
+```
+
+```bash
+# Install
+pip install commitizen
+
+# Create commit interactively
+cz commit
+
+# Bump version and update changelog
+cz bump --changelog
+
+# Check commits
+cz check --rev-range HEAD~5..HEAD
+```
+
+## Release Notes Templates
+
+### GitHub Release Template
+
+```markdown
+## What's Changed
+
+### 🚀 Features
+
+{{ range .Features }}
+
+- {{ .Title }} by @{{ .Author }} in #{{ .PR }}
+  {{ end }}
+
+### 🐛 Bug Fixes
+
+{{ range .Fixes }}
+
+- {{ .Title }} by @{{ .Author }} in #{{ .PR }}
+  {{ end }}
+
+### 📚 Documentation
+
+{{ range .Docs }}
+
+- {{ .Title }} by @{{ .Author }} in #{{ .PR }}
+  {{ end }}
+
+### 🔧 Maintenance
+
+{{ range .Chores }}
+
+- {{ .Title }} by @{{ .Author }} in #{{ .PR }}
+  {{ end }}
+
+## New Contributors
+
+{{ range .NewContributors }}
+
+- @{{ .Username }} made their first contribution in #{{ .PR }}
+  {{ end }}
+
+**Full Changelog**: https://github.com/owner/repo/compare/v{{ .Previous }}...v{{ .Current }}
+```
+
+### Internal Release Notes
+
+```markdown
+# Release v2.1.0 - January 15, 2024
+
+## Summary
+
+This release introduces dark mode support and improves checkout performance
+by 40%. It also includes important security updates.
+
+## Highlights
+
+### 🌙 Dark Mode
+
+Users can now switch to dark mode from settings. The preference is
+automatically saved and synced across devices.
+
+### ⚡ Performance
+
+- Checkout flow is 40% faster
+- Reduced bundle size by 15%
+
+## Breaking Changes
+
+None in this release.
+
+## Upgrade Guide
+
+No special steps required. Standard deployment process applies.
+
+## Known Issues
+
+- Dark mode may flicker on initial load (fix scheduled for v2.1.1)
+
+## Dependencies Updated
+
+| Package | From    | To      | Reason                   |
+| ------- | ------- | ------- | ------------------------ |
+| react   | 18.2.0  | 18.3.0  | Performance improvements |
+| lodash  | 4.17.20 | 4.17.21 | Security patch           |
+```
+
+## Commit Message Examples
+
+```bash
+# Feature with scope
+feat(auth): add OAuth2 support for Google login
+
+# Bug fix with issue reference
+fix(checkout): resolve race condition in payment processing
+
+Closes #123
+
+# Breaking change
+feat(api)!: change user endpoint response format
+
+BREAKING CHANGE: The user endpoint now returns `userId` instead of `id`.
+Migration guide: Update all API consumers to use the new field name.
+
+# Multiple paragraphs
+fix(database): handle connection timeouts gracefully
+
+Previously, connection timeouts would cause the entire request to fail
+without retry. This change implements exponential backoff with up to
+3 retries before failing.
+
+The timeout threshold has been increased from 5s to 10s based on p99
+latency analysis.
+
+Fixes #456
+Reviewed-by: @alice
+```
+
+## Best Practices
+
+### Do's
+
+- **Follow Conventional Commits** - Enables automation
+- **Write clear messages** - Future you will thank you
+- **Reference issues** - Link commits to tickets
+- **Use scopes consistently** - Define team conventions
+- **Automate releases** - Reduce manual errors
+
+### Don'ts
+
+- **Don't mix changes** - One logical change per commit
+- **Don't skip validation** - Use commitlint
+- **Don't manual edit** - Generated changelogs only
+- **Don't forget breaking changes** - Mark with `!` or footer
+- **Don't ignore CI** - Validate commits in pipeline
+
+## Resources
+
+- [Keep a Changelog](https://keepachangelog.com/)
+- [Conventional Commits](https://www.conventionalcommits.org/)
+- [Semantic Versioning](https://semver.org/)
+- [semantic-release](https://semantic-release.gitbook.io/)
+- [git-cliff](https://git-cliff.org/)

--- a/.agents/skills/semantic-versioning/SKILL.md
+++ b/.agents/skills/semantic-versioning/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: semantic-versioning
+description: Implement semantic versioning (SemVer) with automated release management. Use conventional commits, semantic-release, and version bumping strategies.
+---
+
+# Semantic Versioning
+
+## Overview
+
+Establish semantic versioning practices to maintain consistent version numbering aligned with release significance, enabling automated version management and release notes generation.
+
+## When to Use
+
+- Package and library releases
+- API versioning
+- Version bumping automation
+- Release note generation
+- Breaking change tracking
+- Dependency management
+- Changelog management
+
+## Implementation Examples
+
+### 1. **Semantic Versioning Configuration**
+
+```yaml
+# package.json
+{
+  "name": "my-awesome-package",
+  "version": "1.2.3",
+  "description": "An awesome package",
+  "main": "dist/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/org/repo.git"
+  },
+  "scripts": {
+    "release": "semantic-release"
+  },
+  "devDependencies": {
+    "semantic-release": "^21.0.0",
+    "@semantic-release/changelog": "^6.0.0",
+    "@semantic-release/git": "^10.0.0",
+    "@semantic-release/github": "^9.0.0",
+    "conventional-changelog-cli": "^3.0.0"
+  }
+}
+```
+
+### 2. **Conventional Commits Format**
+
+```bash
+# Feature commit (MINOR bump)
+git commit -m "feat: add new search feature"
+git commit -m "feat(api): add pagination support"
+
+# Bug fix commit (PATCH bump)
+git commit -m "fix: resolve null pointer exception"
+git commit -m "fix(auth): fix login timeout issue"
+
+# Breaking change (MAJOR bump)
+git commit -m "feat!: redesign API endpoints"
+git commit -m "feat(api)!: remove deprecated methods"
+
+# Documentation
+git commit -m "docs: update README"
+
+# Performance improvement
+git commit -m "perf: optimize database queries"
+
+# Refactoring
+git commit -m "refactor: simplify authentication logic"
+
+# Tests
+git commit -m "test: add integration tests"
+
+# Chore
+git commit -m "chore: update dependencies"
+
+# Complete example with body and footer
+git commit -m "feat(payment): add Stripe integration
+
+Add support for processing credit card payments via Stripe.
+Includes webhook handling for payment confirmations.
+
+BREAKING CHANGE: Payment API endpoint changed from /pay to /api/v2/payments
+Closes #123"
+```
+
+### 3. **Semantic Release Configuration**
+
+```javascript
+// release.config.js
+module.exports = {
+  branches: ['main', {name: 'develop', prerelease: 'beta'}],
+  plugins: [
+    '@semantic-release/commit-analyzer',
+    '@semantic-release/release-notes-generator',
+    '@semantic-release/changelog',
+    '@semantic-release/git',
+    '@semantic-release/github',
+    '@semantic-release/npm'
+  ]
+};
+```
+
+### 4. **Version Bumping Script**
+
+```bash
+#!/bin/bash
+# bump-version.sh
+
+CURRENT_VERSION=$(grep '"version"' package.json | head -1 | sed 's/.*"version": "\([^"]*\)".*/\1/')
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+
+case "${1:-patch}" in
+  major)
+    NEW_VERSION="$((MAJOR + 1)).0.0"
+    ;;
+  minor)
+    NEW_VERSION="$MAJOR.$((MINOR + 1)).0"
+    ;;
+  patch)
+    NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
+    ;;
+  *)
+    echo "Usage: $0 {major|minor|patch}"
+    exit 1
+    ;;
+esac
+
+echo "Bumping version from $CURRENT_VERSION to $NEW_VERSION"
+
+# Update package.json
+npm version $NEW_VERSION --no-git-tag-v
+
+# Update CHANGELOG
+CHANGELOG_HEADER="## [$NEW_VERSION] - $(date +%Y-%m-%d)"
+sed -i "1i\\$CHANGELOG_HEADER" CHANGELOG.md
+
+# Commit and tag
+git add package.json CHANGELOG.md package-lock.json
+git commit -m "chore(release): version $NEW_VERSION"
+git tag -a "v$NEW_VERSION" -m "Release $NEW_VERSION"
+
+echo "✅ Version bumped to $NEW_VERSION"
+```
+
+### 5. **Changelog Generation**
+
+```bash
+#!/bin/bash
+# generate-changelog.sh
+
+# Using conventional-changelog CLI
+conventional-changelog -p angular -i CHANGELOG.md -s
+
+# Or manually format changelog
+CHANGELOG="# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- New feature description
+
+### Changed
+- Changed feature description
+
+### Deprecated
+- Deprecated feature description
+
+### Removed
+- Removed feature description
+
+### Fixed
+- Bug fix description
+
+### Security
+- Security fix description
+
+## [1.2.0] - 2024-01-15
+
+### Added
+- New search functionality
+- Support for pagination
+
+### Fixed
+- Critical security vulnerability in authentication
+- Memory leak in cache manager"
+
+echo "$CHANGELOG" > CHANGELOG.md
+```
+
+### 6. **GitHub Actions Release Workflow**
+
+```yaml
+name: Semantic Release
+on: [push, workflow_dispatch]
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test
+      - run: npm run build
+      - uses: cycjimmy/semantic-release-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
+## Best Practices
+
+### ✅ DO
+- Follow strict MAJOR.MINOR.PATCH format
+- Use conventional commits
+- Automate version bumping
+- Generate changelogs automatically
+- Tag releases in git
+- Document breaking changes
+- Use prerelease versions for testing
+
+### ❌ DON'T
+- Manually bump versions inconsistently
+- Skip breaking change documentation
+- Use arbitrary version numbering
+- Mix features in patch releases
+
+## Version Examples
+
+```
+1.0.0 → First release
+1.1.0 → New feature
+1.1.1 → Bug fix
+2.0.0 → Breaking changes
+2.0.0-beta.1 → Beta
+```
+
+## Resources
+
+- [Semantic Versioning](https://semver.org/)
+- [Conventional Commits](https://www.conventionalcommits.org/)

--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ SENTRY_UPLOAD_SOURCEMAPS_VITE=false
 # Runtime configuration uses WXT environment variables
 WXT_SENTRY_DSN=
 WXT_SENTRY_ENVIRONMENT=
-WXT_SENTRY_RELEASE=upwork-job-scraper@3.0.0
+WXT_SENTRY_RELEASE=upwork-job-scraper@<package-version>
 WXT_SENTRY_TRACES_SAMPLE_RATE=0.1
 WXT_SENTRY_ENABLE_LOGS=false
 

--- a/.github/prompts/plan-versionCentralization.prompt.md
+++ b/.github/prompts/plan-versionCentralization.prompt.md
@@ -1,0 +1,38 @@
+## Plan: Centralize Versioning in app-v3
+
+We’ll make app-v3/package.json the single canonical version source and remove all other hardcoded version definitions in app-v3 configuration. WXT will then populate manifest version from package metadata automatically, which keeps runtime/UI version display, release workflow tagging, and Sentry release naming aligned without manual syncing. This is the simplest, lowest-risk path because your existing GitHub release workflow already reads package version today. The plan also includes a lightweight guardrail check so CI/build output confirms manifest version stays in sync with package version.
+
+**Steps**
+1. Baseline audit and freeze current version touchpoints.
+   - Confirm current duplicated sources in [app-v3/package.json](app-v3/package.json) and [app-v3/wxt.config.ts](app-v3/wxt.config.ts).
+   - Confirm runtime consumers already use manifest version in [app-v3/components/OptionsApp.tsx](app-v3/components/OptionsApp.tsx), [app-v3/components/OptionsSidebar.tsx](app-v3/components/OptionsSidebar.tsx), and [app-v3/utils/sentry.ts](app-v3/utils/sentry.ts).
+2. Make package.json the only source of truth for extension version.
+   - Remove explicit manifest version hardcoding from [app-v3/wxt.config.ts](app-v3/wxt.config.ts) (including EXTENSION_VERSION-style constants).
+   - Keep manifest config otherwise unchanged so WXT derives version from package metadata.
+3. Align Sentry fallback release computation to the same source.
+   - Update fallback release logic in [app-v3/wxt.config.ts](app-v3/wxt.config.ts) to derive from package version (not a duplicated literal).
+   - Preserve CI override behavior via WXT_SENTRY_RELEASE so release pipeline naming remains intact.
+4. Keep runtime version display behavior as-is.
+   - No structural UI changes; continue reading browser.runtime.getManifest().version through existing flow.
+   - Validate nothing in options UI relies on removed config constants.
+5. Clean docs/examples that can drift.
+   - Update stale version examples in [.env.example](.env.example) to avoid hardcoded numeric drift.
+   - Update versioning guidance in [README.md](README.md) only where it implies multiple version sources.
+6. Validate workflow compatibility explicitly.
+   - Reconfirm [release-publish.yml](.github/workflows/release-publish.yml) still reads version from package and produces tag/release/Sentry values.
+   - Confirm [ci-validate.yml](.github/workflows/ci-validate.yml) requires no logic changes.
+7. Add a verification guard (process-level or script-level, minimal).
+   - During build validation, compare generated manifest version in [app-v3/.output/chrome-mv3/manifest.json](app-v3/.output/chrome-mv3/manifest.json) with package version from [app-v3/package.json](app-v3/package.json).
+   - Fail fast in CI/local validation if mismatch is detected.
+
+**Verification**
+- In app-v3 run compile/build pipeline and ensure success.
+- Check generated manifest version equals package version.
+- Confirm options UI still shows the expected extension version.
+- Confirm release metadata path in [release-publish.yml](.github/workflows/release-publish.yml#L41-L54) remains unchanged and correct.
+
+**Decisions**
+- Canonical version source: [app-v3/package.json](app-v3/package.json).
+- Version format policy: stable numeric x.y.z only.
+- Local Sentry fallback: upwork-job-scraper@<package-version> when env override is absent.
+- GitHub workflows: keep behavior; only validate alignment, no functional workflow redesign.

--- a/.github/workflows/ci-validate.yml
+++ b/.github/workflows/ci-validate.yml
@@ -39,6 +39,20 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Verify manifest version matches package version
+        shell: bash
+        run: |
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          MANIFEST_VERSION="$(node -p "require('./.output/chrome-mv3/manifest.json').version")"
+
+          echo "package.json version: $PACKAGE_VERSION"
+          echo "manifest version: $MANIFEST_VERSION"
+
+          if [[ "$PACKAGE_VERSION" != "$MANIFEST_VERSION" ]]; then
+            echo "Version mismatch: package.json and generated manifest.json differ."
+            exit 1
+          fi
+
       - name: Package ZIP
         run: npm run zip
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -56,6 +56,20 @@ jobs:
           SENTRY_UPLOAD_SOURCEMAPS_VITE: "false"
         run: npm run zip
 
+      - name: Verify manifest version matches package version
+        shell: bash
+        run: |
+          PACKAGE_VERSION="$(node -p "require('./app-v3/package.json').version")"
+          MANIFEST_VERSION="$(node -p "require('./app-v3/.output/chrome-mv3/manifest.json').version")"
+
+          echo "package.json version: $PACKAGE_VERSION"
+          echo "manifest version: $MANIFEST_VERSION"
+
+          if [[ "$PACKAGE_VERSION" != "$MANIFEST_VERSION" ]]; then
+            echo "Version mismatch: app-v3/package.json and built manifest.json differ."
+            exit 1
+          fi
+
       - name: Create or update GitHub release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Release workflow notes:
 
 - CI validates on pull requests via `.github/workflows/ci-validate.yml`.
 - Production release runs on pushes to `main` via `.github/workflows/release-publish.yml`.
+- Extension version source of truth is `app-v3/package.json`; WXT derives manifest version automatically.
 - Sourcemaps are uploaded in CI with `sentry-cli`.
 - Chrome Web Store integration is upload-only in CI; publish remains manual in dashboard.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 A Chrome extension (MV3) that automatically scrapes Upwork job listings from a saved search URL and delivers new results via browser notifications and/or a webhook.
 
+## Chrome Web Store listing
+
+⭐ Chrome Browser Extension ⭐
+
+ [![Available in the Chrome Web Store](https://developer.chrome.com/static/docs/webstore/branding/image/206x58-chrome-web-bcb82d15b2486.png)](https://chromewebstore.google.com/detail/mojpfejnpifdgjjknalhghclnaifnjkg?utm_source=item-share-cb)
+
+Or, click the link here: <https://chromewebstore.google.com/detail/mojpfejnpifdgjjknalhghclnaifnjkg>
+
 ## How it works
 
 1. You provide a search URL from Upwork (e.g. a filtered job search)

--- a/app-v3/package.json
+++ b/app-v3/package.json
@@ -2,7 +2,7 @@
   "name": "upwork-job-scraper",
   "description": "A Chrome extension (MV3) that automatically scrapes Upwork job listings from a saved search URL and delivers new results via browser notifications and/or a webhook.",
   "private": true,
-  "version": "3.0.0",
+  "version": "3.0.1",
   "type": "module",
   "scripts": {
     "dev": "wxt",
@@ -13,6 +13,7 @@
     "zip:firefox": "wxt zip -b firefox",
     "icons": "node ./scripts/generate-icons.mjs",
     "compile": "tsc --noEmit",
+    "verify:version": "node -e \"const pkg=require('./package.json').version; const man=require('./.output/chrome-mv3/manifest.json').version; if(pkg!==man){console.error('Version mismatch: package.json='+pkg+' manifest='+man); process.exit(1)} console.log('Version OK: '+pkg)\"",
     "postinstall": "wxt prepare"
   },
   "dependencies": {

--- a/app-v3/public/example-n8n-workflow.json
+++ b/app-v3/public/example-n8n-workflow.json
@@ -260,7 +260,7 @@
       ]
     }
   },
-  "active": true,
+  "active": false,
   "settings": {
     "executionOrder": "v1",
     "binaryMode": "separate",

--- a/app-v3/public/example-n8n-workflow.json
+++ b/app-v3/public/example-n8n-workflow.json
@@ -170,7 +170,7 @@
     {
       "parameters": {
         "sendTo": "your-email@example.com",
-        "subject": "=⚠️ Upwork Job Scraper - Job Found: {{ $json.title }}",
+        "subject": "✅ Upwork Job Scraper - Job Found: {{ $json.title }}",
         "message": "=<h2><strong>Title:</strong> {{ $json.title }}</h2>\n\n<p><strong><a href=\"{{ $json.url }}\">👉 Click here to see job posting details</a></strong></p>\n\n<p><strong>Description:</strong> {{ $json.description }}</p>",
         "options": {
           "appendAttribution": false

--- a/app-v3/public/example-n8n-workflow.json
+++ b/app-v3/public/example-n8n-workflow.json
@@ -3,6 +3,21 @@
   "nodes": [
     {
       "parameters": {
+        "content": "## Upwork Job Scraper Starter\nThis workflow receives scraper payloads and routes success/error notifications via email.\nGitHub: https://github.com/richardadonnell/Upwork-Job-Scraper",
+        "height": 220,
+        "width": 420
+      },
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -288,
+        -208
+      ],
+      "id": "5f2d9a5e-6abc-4f97-a6c8-0f52f6d8b6aa",
+      "name": "Project Note"
+    },
+    {
+      "parameters": {
         "httpMethod": "POST",
         "path": "upwork-job-scraper-webhook",
         "options": {
@@ -15,32 +30,9 @@
         0,
         0
       ],
-      "id": "ebab9c63-606d-46b3-9071-dd9abd170f22",
+      "id": "940b4a23-0226-43f8-95c0-536147f23b51",
       "name": "Webhook",
       "webhookId": "37d8b5d4-38c2-4224-a39e-dd93c9423008"
-    },
-    {
-      "parameters": {
-        "assignments": {
-          "assignments": [
-            {
-              "id": "6a75ad15-c44b-4709-a841-bb3f67220827",
-              "name": "timestamp_now",
-              "value": "={{ $now.format('yyyy-MM-dd hh:mm:ss') }}",
-              "type": "string"
-            }
-          ]
-        },
-        "options": {}
-      },
-      "type": "n8n-nodes-base.set",
-      "typeVersion": 3.4,
-      "position": [
-        208,
-        0
-      ],
-      "id": "79bd7352-3363-4ac0-903d-0e48b1d713da",
-      "name": "Set Current Date & Time"
     },
     {
       "parameters": {
@@ -56,11 +48,11 @@
                 },
                 "conditions": [
                   {
-                    "leftValue": "={{ $('Webhook').item.json.body }}",
-                    "rightValue": "={{ $('Webhook').item.json.body.type }}",
+                    "leftValue": "={{ $('Webhook').item.json.body.status }}",
+                    "rightValue": "=success",
                     "operator": {
                       "type": "string",
-                      "operation": "notContains"
+                      "operation": "equals"
                     },
                     "id": "b1f79073-7d31-46ce-8151-c37d1639eee8"
                   }
@@ -81,11 +73,11 @@
                 "conditions": [
                   {
                     "id": "9db5c3f8-b03b-4eb5-bdd8-146bcfa53d80",
-                    "leftValue": "={{ $('Webhook').item.json.body }}",
-                    "rightValue": "={{ $('Webhook').item.json.body.type }}",
+                    "leftValue": "={{ $('Webhook').item.json.body.status }}",
+                    "rightValue": "=success",
                     "operator": {
                       "type": "string",
-                      "operation": "contains"
+                      "operation": "notEquals"
                     }
                   }
                 ],
@@ -102,11 +94,116 @@
       "type": "n8n-nodes-base.switch",
       "typeVersion": 3.4,
       "position": [
-        416,
+        448,
         0
       ],
-      "id": "e12ee7f7-c2c7-4022-ba18-e52a34f2dcf2",
-      "name": "No errors or issues?"
+      "id": "85148cc7-9333-4647-9423-cb7b5a0cf682",
+      "name": "Scraper Succeeded?"
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "6a75ad15-c44b-4709-a841-bb3f67220827",
+              "name": "timestamp_now",
+              "value": "={{ $now.format('yyyy-MM-dd hh:mm:ss') }}",
+              "type": "string"
+            },
+            {
+              "id": "3b76fac2-b438-419b-a269-8ee22d55316a",
+              "name": "body.jobs",
+              "value": "={{ $json.body.jobs }}",
+              "type": "array"
+            },
+            {
+              "id": "c3dec13b-35f7-4f0c-b3ca-627f7a2de3d1",
+              "name": "n8n_domain",
+              "value": "https://your-n8n-domain.example.com",
+              "type": "string"
+            },
+            {
+              "id": "c1edd357-264a-466e-a5da-f95db86808a1",
+              "name": "workflow_id",
+              "value": "={{ $workflow.id }}",
+              "type": "string"
+            },
+            {
+              "id": "4ee35eb9-475f-4a14-97ca-49c82ee49d01",
+              "name": "execution_id",
+              "value": "={{ $execution.id }}",
+              "type": "string"
+            },
+            {
+              "id": "dbdd9067-6d2d-42b9-9e9e-29ee088efdc5",
+              "name": "targetName",
+              "value": "={{ $json.body.targetName }}",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        224,
+        0
+      ],
+      "id": "e4dff3d2-f495-4eaa-8c63-147dfd6a457a",
+      "name": "Set Variables"
+    },
+    {
+      "parameters": {
+        "fieldToSplitOut": "body.jobs",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.splitOut",
+      "typeVersion": 1,
+      "position": [
+        672,
+        -96
+      ],
+      "id": "ecaee37c-3cd1-4db8-99f7-a509c00a6c80",
+      "name": "Split Out Scraped Jobs"
+    },
+    {
+      "parameters": {
+        "sendTo": "your-email@example.com",
+        "subject": "=⚠️ Upwork Job Scraper - Job Found: {{ $json.title }}",
+        "message": "=<h2><strong>Title:</strong> {{ $json.title }}</h2>\n\n<p><strong><a href=\"{{ $json.url }}\">👉 Click here to see job posting details</a></strong></p>\n\n<p><strong>Description:</strong> {{ $json.description }}</p>",
+        "options": {
+          "appendAttribution": false
+        }
+      },
+      "type": "n8n-nodes-base.gmail",
+      "typeVersion": 2.2,
+      "position": [
+        896,
+        -96
+      ],
+      "id": "fced3825-5c0a-4ac9-8190-9103609b5ba6",
+      "name": "Send Jobs To Gmail",
+      "webhookId": "d4ee1049-a0a7-4a18-8795-ee3bcc090280"
+    },
+    {
+      "parameters": {
+        "sendTo": "your-email@example.com",
+        "subject": "=⚠️ Upwork Job Scraper: Issue/Error",
+        "message": "=<h2><strong>Upwork Job Scraper:</strong> </h2>\n\n<p>Search Failed: {{ $('Set Variables').item.json.targetName }}</p>\n\n<p><strong>Failed on:</strong> {{ $('Set Variables').item.json.timestamp_now.toDateTime().format('yyyy-MM-dd hh:mm:ss') }}</p>\n\n<p>See Execution Details: <a href=\"{{ $('Set Variables').item.json.n8n_domain }}/workflow/{{ $('Set Variables').item.json.workflow_id }}/executions/{{ $('Set Variables').item.json.execution_id }}\">{{ $('Set Variables').item.json.n8n_domain }}/workflow/{{ $('Set Variables').item.json.workflow_id }}/executions/{{ $('Set Variables').item.json.execution_id }}</a>",
+        "options": {
+          "appendAttribution": false
+        }
+      },
+      "type": "n8n-nodes-base.gmail",
+      "typeVersion": 2.2,
+      "position": [
+        672,
+        96
+      ],
+      "id": "7a1e8a81-2621-4aa8-a2c0-d334dea549da",
+      "name": "Send Errors to Gmail",
+      "webhookId": "d4ee1049-a0a7-4a18-8795-ee3bcc090280"
     }
   ],
   "pinData": {},
@@ -115,18 +212,47 @@
       "main": [
         [
           {
-            "node": "Set Current Date & Time",
+            "node": "Set Variables",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Set Current Date & Time": {
+    "Scraper Succeeded?": {
       "main": [
         [
           {
-            "node": "No errors or issues?",
+            "node": "Split Out Scraped Jobs",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Send Errors to Gmail",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set Variables": {
+      "main": [
+        [
+          {
+            "node": "Scraper Succeeded?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Split Out Scraped Jobs": {
+      "main": [
+        [
+          {
+            "node": "Send Jobs To Gmail",
             "type": "main",
             "index": 0
           }
@@ -134,16 +260,18 @@
       ]
     }
   },
-  "active": false,
+  "active": true,
   "settings": {
     "executionOrder": "v1",
     "binaryMode": "separate",
-    "availableInMCP": false
+    "availableInMCP": false,
+    "timeSavedMode": "fixed",
+    "callerPolicy": "workflowsFromSameOwner"
   },
-  "versionId": "4d1385cd-54fe-4aa3-aa22-ee3c2be31df5",
+  "versionId": "e1293659-7d44-47cb-8e32-d5a3bc66b140",
   "meta": {
-    "instanceId": "ee80817403cc895b536f0dd74844c31381d9f0a69a684b7356490bcb63c3e53b"
+    "templateCredsSetupCompleted": true
   },
-  "id": "Ygoyqy07eZxaLLl2",
+  "id": "dbvA5NHcqq1KdwlU",
   "tags": []
 }

--- a/app-v3/wxt.config.ts
+++ b/app-v3/wxt.config.ts
@@ -1,14 +1,13 @@
 import { sentryVitePlugin } from "@sentry/vite-plugin";
 import { defineConfig } from "wxt";
 
-const EXTENSION_VERSION = "3.0.0";
-const DEFAULT_SENTRY_RELEASE = `upwork-job-scraper@${EXTENSION_VERSION}`;
+const PACKAGE_VERSION = process.env.npm_package_version ?? "0.0.0";
+const DEFAULT_SENTRY_RELEASE = `upwork-job-scraper@${PACKAGE_VERSION}`;
 
 export default defineConfig({
 	modules: ["@wxt-dev/module-react"],
 	manifest: () => ({
 		name: "Upwork Job Scraper",
-		version: EXTENSION_VERSION,
 		description:
 			"Automatically scrape Upwork job listings and send them to a webhook.",
 		permissions: ["storage", "tabs", "scripting", "alarms", "notifications"],

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -56,6 +56,11 @@
       "sourceType": "github",
       "computedHash": "53050903051c0718a82c0f4decdb34e8adbc7cd871b8407d83c46b08d4599357"
     },
+    "semantic-versioning": {
+      "source": "aj-geddes/useful-ai-prompts",
+      "sourceType": "github",
+      "computedHash": "f4a7f7096d6e237eb6cb7cd0948fcf830e4df83ff7d5df2f73bc4cfa033cea03"
+    },
     "sentry-create-alert": {
       "source": "getsentry/sentry-agent-skills",
       "sourceType": "github",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,6 +1,11 @@
 {
   "version": 1,
   "skills": {
+    "changelog-automation": {
+      "source": "wshobson/agents",
+      "sourceType": "github",
+      "computedHash": "87e8104a7842f5fff034e926ae7ae6fa20708a2735284b6e6906f681bc060f74"
+    },
     "find-skills": {
       "source": "vercel-labs/skills",
       "sourceType": "github",


### PR DESCRIPTION
Establish app-v3/package.json as the sole source of truth for versioning, removing hardcoded definitions and ensuring the manifest version aligns with package metadata. Introduce verification steps in CI workflows to maintain version consistency and update documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added two new skills docs covering semantic versioning and changelog automation
  * Updated README with Chrome Web Store listing and version-source note

* **New Features**
  * Enhanced example n8n workflow to send email notifications for successes and errors

* **Chores**
  * Bumped app version to 3.0.1
  * Added version verification to CI and release workflows to keep manifest/package versions aligned
* **Lockfile**
  * Added entries for new skills to the skills lockfile
<!-- end of auto-generated comment: release notes by coderabbit.ai -->