### PR TITLE
Enhance job notification click handlers

### DIFF
--- a/app-v3/entrypoints/background.ts
+++ b/app-v3/entrypoints/background.ts
@@ -30,6 +30,27 @@ export default defineBackground(() => {
 		browser.runtime.openOptionsPage();
 	});
 
+	// Handle notification body click
+	browser.notifications.onClicked.addListener((notificationId) => {
+		if (notificationId.startsWith("job|")) {
+			browser.tabs.create({ url: notificationId.slice(4) });
+		} else {
+			browser.runtime.openOptionsPage();
+		}
+	});
+
+	// Handle notification button click
+	browser.notifications.onButtonClicked.addListener(
+		(notificationId, buttonIndex) => {
+			if (buttonIndex === 0) {
+				browser.runtime.openOptionsPage();
+			} else if (buttonIndex === 1 && notificationId.startsWith("job|")) {
+				browser.tabs.create({ url: notificationId.slice(4) });
+			}
+			browser.notifications.clear(notificationId);
+		},
+	);
+
 	// Set up alarm on install/update
 	browser.runtime.onInstalled.addListener(() => {
 		initializeFromLifecycle("installed").catch((err) => {

--- a/app-v3/entrypoints/background.ts
+++ b/app-v3/entrypoints/background.ts
@@ -33,10 +33,16 @@ export default defineBackground(() => {
 	// Handle notification body click
 	browser.notifications.onClicked.addListener((notificationId) => {
 		if (notificationId.startsWith("job|")) {
-			browser.tabs.create({ url: notificationId.slice(4) });
+			const url = notificationId.slice(4);
+			if (url) {
+				browser.tabs.create({ url });
+			} else {
+				browser.runtime.openOptionsPage();
+			}
 		} else {
 			browser.runtime.openOptionsPage();
 		}
+		browser.notifications.clear(notificationId);
 	});
 
 	// Handle notification button click
@@ -45,7 +51,12 @@ export default defineBackground(() => {
 			if (buttonIndex === 0) {
 				browser.runtime.openOptionsPage();
 			} else if (buttonIndex === 1 && notificationId.startsWith("job|")) {
-				browser.tabs.create({ url: notificationId.slice(4) });
+				const url = notificationId.slice(4);
+				if (url) {
+					browser.tabs.create({ url });
+				} else {
+					browser.runtime.openOptionsPage();
+				}
 			}
 			browser.notifications.clear(notificationId);
 		},

--- a/app-v3/utils/scraper.ts
+++ b/app-v3/utils/scraper.ts
@@ -475,6 +475,7 @@ async function processTargetResult(
 
 	if (notificationsEnabled) {
 		for (const job of newJobs.slice(0, 3)) {
+			if (!job.url) continue;
 			browser.notifications.create(`job|${job.url}`, {
 				type: "basic",
 				iconUrl: "/icon/128.png",

--- a/app-v3/utils/scraper.ts
+++ b/app-v3/utils/scraper.ts
@@ -475,19 +475,21 @@ async function processTargetResult(
 
 	if (notificationsEnabled) {
 		for (const job of newJobs.slice(0, 3)) {
-			browser.notifications.create({
+			browser.notifications.create(`job|${job.url}`, {
 				type: "basic",
 				iconUrl: "/icon/128.png",
 				title: "New Upwork Job",
 				message: job.title,
+				buttons: [{ title: "Open Extension" }, { title: "View Job" }],
 			});
 		}
 		if (newJobs.length > 3) {
-			browser.notifications.create({
+			browser.notifications.create("bulk-jobs", {
 				type: "basic",
 				iconUrl: "/icon/128.png",
 				title: "New Upwork Jobs",
 				message: `${newJobs.length} new jobs found — open the extension to view them.`,
+				buttons: [{ title: "Open Extension" }],
 			});
 		}
 	}


### PR DESCRIPTION
Improve user interaction with job notifications by adding click handlers for both the notification body and action buttons. This allows users to open job URLs or the options page directly from the notifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Job notifications now include action buttons: "Open Extension" and "View Job".
  * Clicking a job notification or its buttons opens the job in a new tab when available, otherwise opens the extension options; notifications are dismissed after interaction.
  * Bulk job alerts consolidate many results and include a single "Open Extension" action.
  * Notifications skip entries without a job URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->