### PR TITLE
Implement webhook error tracking and notifications

### DIFF
--- a/app-v3/components/OptionsApp.tsx
+++ b/app-v3/components/OptionsApp.tsx
@@ -6,6 +6,7 @@ import {
 	jobHistoryStorage,
 	sanitizeSettings,
 	settingsStorage,
+	webhookErrorsStorage,
 } from "../utils/storage";
 import type { Job, Settings } from "../utils/types";
 
@@ -213,6 +214,7 @@ export function OptionsApp() {
 	>(null);
 	const [saveState, setSaveState] = useState<SaveState>("idle");
 	const [showSaveSuccess, setShowSaveSuccess] = useState(false);
+	const [webhookErrors, setWebhookErrors] = useState<Record<string, { message: string; timestamp: number }>>({})
 	const saveTimeoutRef = useRef<number | null>(null);
 	const saveStatusTimeoutRef = useRef<number | null>(null);
 	const lastSavedSnapshotRef = useRef("");
@@ -221,10 +223,12 @@ export function OptionsApp() {
 		Promise.all([
 			settingsStorage.getValue(),
 			jobHistoryStorage.getValue(),
-		]).then(([s, j]) => {
+			webhookErrorsStorage.getValue(),
+		]).then(([s, j, we]) => {
 			const sanitizedSettings = sanitizeSettings(s);
 			setSettings(sanitizedSettings);
 			setJobs(j);
+			setWebhookErrors(we);
 			lastSavedSnapshotRef.current = JSON.stringify(sanitizedSettings);
 			setLoading(false);
 		});
@@ -232,9 +236,13 @@ export function OptionsApp() {
 			setSettings(sanitizeSettings(s)),
 		);
 		const unwatchJobs = jobHistoryStorage.watch((j) => setJobs(j));
+		const unwatchWebhookErrors = webhookErrorsStorage.watch((we) =>
+			setWebhookErrors(we),
+		);
 		return () => {
 			unwatchSettings();
 			unwatchJobs();
+			unwatchWebhookErrors();
 		};
 	}, []);
 
@@ -419,7 +427,7 @@ export function OptionsApp() {
 					<DashboardPage settings={settings} jobs={jobs} />
 				)}
 				{activePage === "search-targets" && (
-					<SearchTargetsPage settings={settings} onChange={setSettings} />
+					<SearchTargetsPage settings={settings} onChange={setSettings} webhookErrors={webhookErrors} />
 				)}
 				{activePage === "schedule" && (
 					<SchedulePage settings={settings} onChange={setSettings} />

--- a/app-v3/components/OptionsApp.tsx
+++ b/app-v3/components/OptionsApp.tsx
@@ -214,7 +214,7 @@ export function OptionsApp() {
 	>(null);
 	const [saveState, setSaveState] = useState<SaveState>("idle");
 	const [showSaveSuccess, setShowSaveSuccess] = useState(false);
-	const [webhookErrors, setWebhookErrors] = useState<Record<string, { message: string; timestamp: number }>>({})
+	const [webhookErrors, setWebhookErrors] = useState<Record<string, { message: string; timestamp: number }>>({});
 	const saveTimeoutRef = useRef<number | null>(null);
 	const saveStatusTimeoutRef = useRef<number | null>(null);
 	const lastSavedSnapshotRef = useRef("");

--- a/app-v3/components/SearchTargetsPage.tsx
+++ b/app-v3/components/SearchTargetsPage.tsx
@@ -17,6 +17,7 @@ import {
 	TextField,
 } from "@radix-ui/themes";
 import { useState } from "react";
+import { is4xxStatus } from "../utils/scraper";
 import {
 	captureContextException,
 	captureContextMessage,
@@ -108,7 +109,7 @@ function SearchTargetCard({
 			});
 			if (!res.ok) {
 				const webhookError = classifyWebhookError({ response: res });
-				if (res.status < 400 || res.status >= 500) {
+				if (!is4xxStatus(res.status)) {
 					captureContextMessage("options", "Webhook test failed", {
 						operation: "handleTestWebhook",
 						stage: "webhook_test",

--- a/app-v3/components/SearchTargetsPage.tsx
+++ b/app-v3/components/SearchTargetsPage.tsx
@@ -1,5 +1,6 @@
 import {
 	DownloadIcon,
+	ExclamationTriangleIcon,
 	ExternalLinkIcon,
 	InfoCircledIcon,
 } from "@radix-ui/react-icons";
@@ -30,6 +31,10 @@ import {
 interface Props {
 	readonly settings: Settings;
 	readonly onChange: (s: Settings) => void;
+	readonly webhookErrors: Record<
+		string,
+		{ message: string; timestamp: number }
+	>;
 }
 
 type TestStatus = "idle" | "sending" | "ok" | "error";
@@ -56,12 +61,14 @@ function SearchTargetCard({
 	total,
 	onChange,
 	onRemove,
+	webhookError,
 }: {
 	readonly target: SearchTarget;
 	readonly index: number;
 	readonly total: number;
 	readonly onChange: (t: SearchTarget) => void;
 	readonly onRemove: () => void;
+	readonly webhookError?: { message: string; timestamp: number };
 }) {
 	const [testStatus, setTestStatus] = useState<TestStatus>("idle");
 	const canUseLegacyPayload = target.legacyCompatibilityEligible;
@@ -101,16 +108,18 @@ function SearchTargetCard({
 			});
 			if (!res.ok) {
 				const webhookError = classifyWebhookError({ response: res });
-				captureContextMessage("options", "Webhook test failed", {
-					operation: "handleTestWebhook",
-					stage: "webhook_test",
-					status: res.status,
-					targetName,
-					targetUrl: target.searchUrl,
-					webhookErrorKind: webhookError.kind,
-					httpStatus: webhookError.httpStatus,
-					normalizedMessage: webhookError.message,
-				});
+				if (res.status < 400 || res.status >= 500) {
+					captureContextMessage("options", "Webhook test failed", {
+						operation: "handleTestWebhook",
+						stage: "webhook_test",
+						status: res.status,
+						targetName,
+						targetUrl: target.searchUrl,
+						webhookErrorKind: webhookError.kind,
+						httpStatus: webhookError.httpStatus,
+						normalizedMessage: webhookError.message,
+					});
+				}
 			}
 			setTestStatus(res.ok ? "ok" : "error");
 			setTimeout(() => setTestStatus("idle"), res.ok ? 3000 : 4000);
@@ -287,6 +296,19 @@ function SearchTargetCard({
 						</Text>
 					)}
 
+					{webhookError && (
+						<Callout.Root mt="3" size="1" color="red" variant="soft">
+							<Callout.Icon>
+								<ExclamationTriangleIcon />
+							</Callout.Icon>
+							<Callout.Text>
+								<strong>Webhook delivery failed:</strong> {webhookError.message}
+								. Last error at{" "}
+								{new Date(webhookError.timestamp).toLocaleString()}.
+							</Callout.Text>
+						</Callout.Root>
+					)}
+
 					{canUseLegacyPayload ? (
 						<>
 							<Flex justify="between" align="start" gap="3" mt="3">
@@ -328,7 +350,11 @@ function SearchTargetCard({
 	);
 }
 
-export function SearchTargetsPage({ settings, onChange }: Props) {
+export function SearchTargetsPage({
+	settings,
+	onChange,
+	webhookErrors,
+}: Props) {
 	const safeSearchTargets = Array.isArray(settings.searchTargets)
 		? settings.searchTargets
 		: [];
@@ -400,6 +426,7 @@ export function SearchTargetsPage({ settings, onChange }: Props) {
 					target={target}
 					index={i}
 					total={safeSearchTargets.length}
+					webhookError={webhookErrors[target.id]}
 					onChange={(updated) => {
 						const next = safeSearchTargets.map((t) =>
 							t.id === updated.id ? updated : t,

--- a/app-v3/package.json
+++ b/app-v3/package.json
@@ -2,7 +2,7 @@
   "name": "upwork-job-scraper",
   "description": "A Chrome extension (MV3) that automatically scrapes Upwork job listings from a saved search URL and delivers new results via browser notifications and/or a webhook.",
   "private": true,
-  "version": "3.2.0",
+  "version": "3.2.1",
   "type": "module",
   "scripts": {
     "dev": "wxt",

--- a/app-v3/package.json
+++ b/app-v3/package.json
@@ -2,7 +2,7 @@
   "name": "upwork-job-scraper",
   "description": "A Chrome extension (MV3) that automatically scrapes Upwork job listings from a saved search URL and delivers new results via browser notifications and/or a webhook.",
   "private": true,
-  "version": "3.1.0",
+  "version": "3.2.0",
   "type": "module",
   "scripts": {
     "dev": "wxt",

--- a/app-v3/utils/scraper.ts
+++ b/app-v3/utils/scraper.ts
@@ -1,4 +1,4 @@
-import { captureContextException, classifyWebhookError } from "./sentry";
+import { captureContextException, classifyWebhookError, type ClassifiedWebhookError } from "./sentry";
 import {
 	appendActivityLog,
 	JOB_HISTORY_MAX,
@@ -6,6 +6,8 @@ import {
 	sanitizeSettings,
 	seenJobIdsStorage,
 	settingsStorage,
+	webhookErrorsStorage,
+	webhookFailureCountsStorage,
 } from "./storage";
 import type {
 	Job,
@@ -341,6 +343,51 @@ async function scrapeTarget(target: SearchTarget): Promise<ScrapeResult> {
 	}
 }
 
+const WEBHOOK_FAILURE_NOTIFICATION_THRESHOLD = 3;
+
+function is4xxStatus(httpStatus: number | undefined): boolean {
+	return typeof httpStatus === "number" && httpStatus >= 400 && httpStatus < 500;
+}
+
+async function trackWebhookFailure(
+	target: SearchTarget,
+	webhookError: ClassifiedWebhookError,
+): Promise<void> {
+	const [counts, errors] = await Promise.all([
+		webhookFailureCountsStorage.getValue(),
+		webhookErrorsStorage.getValue(),
+	]);
+	const newCount = (counts[target.id] ?? 0) + 1;
+	await Promise.all([
+		webhookFailureCountsStorage.setValue({ ...counts, [target.id]: newCount }),
+		webhookErrorsStorage.setValue({
+			...errors,
+			[target.id]: { message: webhookError.message, timestamp: Date.now() },
+		}),
+	]);
+	if (newCount === WEBHOOK_FAILURE_NOTIFICATION_THRESHOLD) {
+		browser.notifications.create(`webhook-error|${target.id}`, {
+			type: "basic",
+			iconUrl: "/icon/128.png",
+			title: "Webhook Delivery Error",
+			message: `"${target.name}" webhook has failed 3 times in a row. Check your webhook URL in Settings.`,
+		});
+	}
+}
+
+async function clearWebhookFailureState(target: SearchTarget): Promise<void> {
+	const [counts, errors] = await Promise.all([
+		webhookFailureCountsStorage.getValue(),
+		webhookErrorsStorage.getValue(),
+	]);
+	const { [target.id]: _c, ...restCounts } = counts;
+	const { [target.id]: _e, ...restErrors } = errors;
+	await Promise.all([
+		webhookFailureCountsStorage.setValue(restCounts),
+		webhookErrorsStorage.setValue(restErrors),
+	]);
+}
+
 async function processTargetResult(
 	target: SearchTarget,
 	result: ScrapeResult,
@@ -436,13 +483,16 @@ async function processTargetResult(
 
 			if (!response.ok) {
 				const webhookError = classifyWebhookError({ response });
-				captureContextException("background", new Error(webhookError.message), {
-					operation: "processTargetResult-webhook",
-					stage: "webhook_delivery",
-					targetUrl: target.searchUrl,
-					webhookErrorKind: webhookError.kind,
-					httpStatus: webhookError.httpStatus,
-				});
+				if (!is4xxStatus(webhookError.httpStatus)) {
+					captureContextException("background", new Error(webhookError.message), {
+						operation: "processTargetResult-webhook",
+						stage: "webhook_delivery",
+						targetUrl: target.searchUrl,
+						webhookErrorKind: webhookError.kind,
+						httpStatus: webhookError.httpStatus,
+					});
+				}
+				await trackWebhookFailure(target, webhookError);
 				await appendActivityLog(
 					"error",
 					`Webhook failed (${webhookError.kind}): ${webhookError.message}`,
@@ -450,6 +500,7 @@ async function processTargetResult(
 				);
 				return newJobs.length;
 			}
+			await clearWebhookFailureState(target);
 			await appendActivityLog("info", "Webhook delivered", target.searchUrl);
 		} catch (err) {
 			const webhookError = classifyWebhookError({ error: err });
@@ -538,14 +589,17 @@ async function sendIssueWebhookIfNeeded(
 
 		if (!response.ok) {
 			const webhookError = classifyWebhookError({ response });
-			captureContextException("background", new Error(webhookError.message), {
-				operation: "sendIssueWebhookIfNeeded",
-				stage: "webhook_delivery",
-				targetUrl: target.searchUrl,
-				reason: result.reason ?? "unknown",
-				webhookErrorKind: webhookError.kind,
-				httpStatus: webhookError.httpStatus,
-			});
+			if (!is4xxStatus(webhookError.httpStatus)) {
+				captureContextException("background", new Error(webhookError.message), {
+					operation: "sendIssueWebhookIfNeeded",
+					stage: "webhook_delivery",
+					targetUrl: target.searchUrl,
+					reason: result.reason ?? "unknown",
+					webhookErrorKind: webhookError.kind,
+					httpStatus: webhookError.httpStatus,
+				});
+			}
+			await trackWebhookFailure(target, webhookError);
 			await appendActivityLog(
 				"error",
 				`Issue webhook failed (${webhookError.kind}): ${webhookError.message}`,

--- a/app-v3/utils/scraper.ts
+++ b/app-v3/utils/scraper.ts
@@ -349,7 +349,7 @@ async function scrapeTarget(target: SearchTarget): Promise<ScrapeResult> {
 
 const WEBHOOK_FAILURE_NOTIFICATION_THRESHOLD = 3;
 
-function is4xxStatus(httpStatus: number | undefined): boolean {
+export function is4xxStatus(httpStatus: number | undefined): boolean {
 	return (
 		typeof httpStatus === "number" && httpStatus >= 400 && httpStatus < 500
 	);
@@ -617,6 +617,7 @@ async function sendIssueWebhookIfNeeded(
 			);
 			return;
 		}
+		await clearWebhookFailureState(target);
 		await appendActivityLog(
 			"info",
 			"Issue webhook delivered",

--- a/app-v3/utils/scraper.ts
+++ b/app-v3/utils/scraper.ts
@@ -1,4 +1,8 @@
-import { captureContextException, classifyWebhookError, type ClassifiedWebhookError } from "./sentry";
+import {
+	type ClassifiedWebhookError,
+	captureContextException,
+	classifyWebhookError,
+} from "./sentry";
 import {
 	appendActivityLog,
 	JOB_HISTORY_MAX,
@@ -346,7 +350,9 @@ async function scrapeTarget(target: SearchTarget): Promise<ScrapeResult> {
 const WEBHOOK_FAILURE_NOTIFICATION_THRESHOLD = 3;
 
 function is4xxStatus(httpStatus: number | undefined): boolean {
-	return typeof httpStatus === "number" && httpStatus >= 400 && httpStatus < 500;
+	return (
+		typeof httpStatus === "number" && httpStatus >= 400 && httpStatus < 500
+	);
 }
 
 async function trackWebhookFailure(
@@ -484,13 +490,17 @@ async function processTargetResult(
 			if (!response.ok) {
 				const webhookError = classifyWebhookError({ response });
 				if (!is4xxStatus(webhookError.httpStatus)) {
-					captureContextException("background", new Error(webhookError.message), {
-						operation: "processTargetResult-webhook",
-						stage: "webhook_delivery",
-						targetUrl: target.searchUrl,
-						webhookErrorKind: webhookError.kind,
-						httpStatus: webhookError.httpStatus,
-					});
+					captureContextException(
+						"background",
+						new Error(webhookError.message),
+						{
+							operation: "processTargetResult-webhook",
+							stage: "webhook_delivery",
+							targetUrl: target.searchUrl,
+							webhookErrorKind: webhookError.kind,
+							httpStatus: webhookError.httpStatus,
+						},
+					);
 				}
 				await trackWebhookFailure(target, webhookError);
 				await appendActivityLog(

--- a/app-v3/utils/storage.ts
+++ b/app-v3/utils/storage.ts
@@ -236,6 +236,16 @@ export const activityLogsStorage = storage.defineItem<ActivityLog[]>('local:acti
   fallback: [],
 });
 
+export const webhookFailureCountsStorage = storage.defineItem<Record<string, number>>(
+  'local:webhookFailureCounts',
+  { fallback: {} },
+);
+
+export const webhookErrorsStorage = storage.defineItem<Record<string, { message: string; timestamp: number }>>(
+  'local:webhookErrors',
+  { fallback: {} },
+);
+
 export const legacyV1MigrationAppliedStorage = storage.defineItem<boolean>(
   'local:legacyV1MigrationApplied',
   {


### PR DESCRIPTION
Introduce a system to track webhook failures and notify users after three consecutive failures. Update relevant components to handle and display webhook error states effectively. Refactor existing functions to integrate this new error management system.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webhook error messages with timestamps now display in the search targets UI when delivery fails.
  * Visual error indicators added to highlight webhook issues per target.
  * User notifications fire after three consecutive webhook failures.

* **Bug Fixes**
  * Improved webhook error handling: 4xx client errors are tracked locally but suppressed from extra system logging.

* **Chores**
  * Version bumped to 3.2.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->