### PR TITLE
fix(scraper): resolve Tab load timeout failures (Fixes #136)

### DIFF
--- a/app-v3/package-lock.json
+++ b/app-v3/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "upwork-job-scraper",
-  "version": "3.0.0",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "upwork-job-scraper",
-      "version": "3.0.0",
+      "version": "3.3.0",
       "hasInstallScript": true,
       "dependencies": {
         "@radix-ui/react-icons": "^1.3.2",

--- a/app-v3/utils/scraper.ts
+++ b/app-v3/utils/scraper.ts
@@ -145,6 +145,18 @@ function isChromeErrorUrl(url: string | undefined): boolean {
 	return typeof url === "string" && url.startsWith("chrome-error://");
 }
 
+function hasExpectedOrigin(
+	url: string | undefined,
+	expectedOrigin: string,
+): boolean {
+	if (typeof url !== "string" || url === "") return false;
+	try {
+		return new URL(url).origin === expectedOrigin;
+	} catch {
+		return false;
+	}
+}
+
 async function waitForTabComplete(
 	tabId: number,
 	expectedOrigin: string,
@@ -154,7 +166,7 @@ async function waitForTabComplete(
 		if (isChromeErrorUrl(currentTab.url)) {
 			throw new Error("Chrome error page");
 		}
-		if (currentTab.url?.startsWith(expectedOrigin)) {
+		if (hasExpectedOrigin(currentTab.url, expectedOrigin)) {
 			return;
 		}
 	}
@@ -192,8 +204,7 @@ async function waitForTabComplete(
 
 			if (updatedTab.status !== "complete") return;
 
-			const finalUrl = updatedTab.url ?? "";
-			if (finalUrl.startsWith(expectedOrigin)) {
+			if (hasExpectedOrigin(updatedTab.url, expectedOrigin)) {
 				cleanup();
 				resolve();
 			}
@@ -787,46 +798,16 @@ export async function runScrape(options?: { manual?: boolean }): Promise<void> {
 	let anyLoggedOut = false;
 	let anyCaptchaRequired = false;
 
+	// Scrape phase: run in parallel (capped). The phase is pure I/O against
+	// Upwork tabs; it does NOT touch shared storage (seenJobIdsStorage,
+	// jobHistoryStorage, activityLogsStorage), which would otherwise race
+	// under read-modify-write semantics with concurrency > 1.
 	const scrapeOutcomes = await runWithConcurrency(
 		activeTargets,
 		TARGET_CONCURRENCY,
 		async (target) => {
 			try {
-				const result = await scrapeTargetWithRetry(target);
-				const newCount = await processTargetResult(
-					target,
-					result,
-					settings.notificationsEnabled,
-				);
-
-				if (result.ok && result.jobs) {
-					await appendActivityLog(
-						"info",
-						`Scraped: ${newCount} new job${newCount !== 1 ? "s" : ""} found`,
-						target.searchUrl,
-					);
-				} else if (result.reason === "captcha_required") {
-					await appendActivityLog(
-						"warn",
-						"Cloudflare verification required — complete captcha manually to resume scraping",
-						target.searchUrl,
-					);
-				} else if (result.reason === "logged_out") {
-					await appendActivityLog(
-						"warn",
-						"Logged out — please sign in to Upwork",
-						target.searchUrl,
-					);
-				} else if (result.reason === "no_results") {
-					await appendActivityLog("info", "No results found", target.searchUrl);
-				} else {
-					await appendActivityLog(
-						"error",
-						`Scrape failed: ${result.error ?? "unknown error"}`,
-						target.searchUrl,
-					);
-				}
-				return result;
+				return await scrapeTargetWithRetry(target);
 			} catch (err) {
 				captureContextException("background", err, {
 					operation: "runScrape-target",
@@ -837,17 +818,56 @@ export async function runScrape(options?: { manual?: boolean }): Promise<void> {
 					`[Upwork Scraper] Scrape error for ${target.searchUrl}:`,
 					err,
 				);
-				await appendActivityLog(
-					"error",
-					`Scrape failed: ${String(err)}`,
-					target.searchUrl,
-				);
-				return { ok: false, reason: "error" } as ScrapeResult;
+				return {
+					ok: false,
+					reason: "error",
+					error: String(err),
+				} as ScrapeResult;
 			}
 		},
 	);
 
-	for (const result of scrapeOutcomes) {
+	// Post-process phase: sequential. processTargetResult and appendActivityLog
+	// each perform read-modify-write on shared extension storage, so they must
+	// not interleave across targets.
+	for (let i = 0; i < activeTargets.length; i++) {
+		const target = activeTargets[i];
+		const result = scrapeOutcomes[i];
+
+		const newCount = await processTargetResult(
+			target,
+			result,
+			settings.notificationsEnabled,
+		);
+
+		if (result.ok && result.jobs) {
+			await appendActivityLog(
+				"info",
+				`Scraped: ${newCount} new job${newCount !== 1 ? "s" : ""} found`,
+				target.searchUrl,
+			);
+		} else if (result.reason === "captcha_required") {
+			await appendActivityLog(
+				"warn",
+				"Cloudflare verification required — complete captcha manually to resume scraping",
+				target.searchUrl,
+			);
+		} else if (result.reason === "logged_out") {
+			await appendActivityLog(
+				"warn",
+				"Logged out — please sign in to Upwork",
+				target.searchUrl,
+			);
+		} else if (result.reason === "no_results") {
+			await appendActivityLog("info", "No results found", target.searchUrl);
+		} else {
+			await appendActivityLog(
+				"error",
+				`Scrape failed: ${result.error ?? "unknown error"}`,
+				target.searchUrl,
+			);
+		}
+
 		if (isCaptchaRequiredResult(result)) anyCaptchaRequired = true;
 		else if (isLoggedOutResult(result)) anyLoggedOut = true;
 		else if (isErrorResult(result)) anyError = true;

--- a/app-v3/utils/scraper.ts
+++ b/app-v3/utils/scraper.ts
@@ -141,16 +141,22 @@ async function resolveWindowIdForBackgroundTab(): Promise<number | undefined> {
 	return windows.find((window) => typeof window.id === "number")?.id;
 }
 
+function isChromeErrorUrl(url: string | undefined): boolean {
+	return typeof url === "string" && url.startsWith("chrome-error://");
+}
+
 async function waitForTabComplete(
 	tabId: number,
-	expectedBase: string,
+	expectedOrigin: string,
 ): Promise<void> {
 	const currentTab = await browser.tabs.get(tabId).catch(() => null);
-	if (
-		currentTab?.status === "complete" &&
-		currentTab.url?.startsWith(expectedBase)
-	) {
-		return;
+	if (currentTab?.status === "complete") {
+		if (isChromeErrorUrl(currentTab.url)) {
+			throw new Error("Chrome error page");
+		}
+		if (currentTab.url?.startsWith(expectedOrigin)) {
+			return;
+		}
 	}
 
 	await new Promise<void>((resolve, reject) => {
@@ -173,14 +179,21 @@ async function waitForTabComplete(
 
 		const onUpdated = (
 			updatedTabId: number,
-			_changeInfo: unknown,
+			changeInfo: { status?: string; url?: string },
 			updatedTab: { status?: string; url?: string },
 		) => {
-			if (
-				updatedTabId === tabId &&
-				updatedTab.status === "complete" &&
-				updatedTab.url?.startsWith(expectedBase)
-			) {
+			if (updatedTabId !== tabId) return;
+
+			if (isChromeErrorUrl(changeInfo.url) || isChromeErrorUrl(updatedTab.url)) {
+				cleanup();
+				reject(new Error("Chrome error page"));
+				return;
+			}
+
+			if (updatedTab.status !== "complete") return;
+
+			const finalUrl = updatedTab.url ?? "";
+			if (finalUrl.startsWith(expectedOrigin)) {
 				cleanup();
 				resolve();
 			}
@@ -239,12 +252,14 @@ async function scrapeTarget(target: SearchTarget): Promise<ScrapeResult> {
 		const tabId = tab.id;
 		tabIdToRemove = tabId;
 
-		// Build the base URL (origin + pathname) so we wait for the actual search
-		// results page, not an intermediate Cloudflare challenge redirect.
-		const { origin, pathname } = new URL(target.searchUrl);
-		const expectedBase = origin + pathname;
+		// Match on origin only. Upwork bounces tabs through Cloudflare challenges,
+		// login redirects, and other same-origin paths before settling; pathname-strict
+		// matching meant we waited the full 60s timeout instead of letting Phase 2
+		// detect the captcha/login state. Phase 2 still polls 10s for job cards or
+		// Cloudflare markers, so loosening this check is safe.
+		const { origin } = new URL(target.searchUrl);
 
-		await waitForTabComplete(tabId, expectedBase);
+		await waitForTabComplete(tabId, origin);
 
 		// Upwork is a React SPA — job cards are rendered asynchronously after the
 		// browser fires status:complete. Use an inline executeScript (MV3 awaits
@@ -328,6 +343,14 @@ async function scrapeTarget(target: SearchTarget): Promise<ScrapeResult> {
 				ok: false,
 				reason: "error",
 				error: "Tab load timeout",
+			};
+		}
+
+		if (/Chrome error page/i.test(toErrorMessage(error))) {
+			return {
+				ok: false,
+				reason: "error",
+				error: "Chrome error page (network failure)",
 			};
 		}
 

--- a/app-v3/utils/scraper.ts
+++ b/app-v3/utils/scraper.ts
@@ -696,6 +696,54 @@ function isErrorResult(result: ScrapeResult): boolean {
 	);
 }
 
+const TARGET_CONCURRENCY = 2;
+const TAB_TIMEOUT_RETRY_DELAY_MS = 7_000;
+
+async function scrapeTargetWithRetry(
+	target: SearchTarget,
+): Promise<ScrapeResult> {
+	const first = await scrapeTarget(target);
+
+	const shouldRetry =
+		!first.ok &&
+		first.reason === "error" &&
+		typeof first.error === "string" &&
+		/Tab load timeout/i.test(first.error);
+
+	if (!shouldRetry) return first;
+
+	console.warn(
+		`[Upwork Scraper] Tab load timeout for ${target.searchUrl} — retrying once after ${TAB_TIMEOUT_RETRY_DELAY_MS}ms`,
+	);
+	await new Promise((r) => setTimeout(r, TAB_TIMEOUT_RETRY_DELAY_MS));
+	return scrapeTarget(target);
+}
+
+async function runWithConcurrency<T, R>(
+	items: readonly T[],
+	limit: number,
+	worker: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+	const results = new Array<R>(items.length);
+	let cursor = 0;
+
+	const runOne = async (): Promise<void> => {
+		while (true) {
+			const index = cursor;
+			cursor += 1;
+			if (index >= items.length) return;
+			results[index] = await worker(items[index], index);
+		}
+	};
+
+	const workers = Array.from(
+		{ length: Math.min(limit, items.length) },
+		runOne,
+	);
+	await Promise.all(workers);
+	return results;
+}
+
 export async function runScrape(options?: { manual?: boolean }): Promise<void> {
 	const settings = sanitizeSettings(await settingsStorage.getValue());
 
@@ -739,10 +787,12 @@ export async function runScrape(options?: { manual?: boolean }): Promise<void> {
 	let anyLoggedOut = false;
 	let anyCaptchaRequired = false;
 
-	const scrapeOutcomes = await Promise.all(
-		activeTargets.map(async (target) => {
+	const scrapeOutcomes = await runWithConcurrency(
+		activeTargets,
+		TARGET_CONCURRENCY,
+		async (target) => {
 			try {
-				const result = await scrapeTarget(target);
+				const result = await scrapeTargetWithRetry(target);
 				const newCount = await processTargetResult(
 					target,
 					result,
@@ -794,7 +844,7 @@ export async function runScrape(options?: { manual?: boolean }): Promise<void> {
 				);
 				return { ok: false, reason: "error" } as ScrapeResult;
 			}
-		}),
+		},
 	);
 
 	for (const result of scrapeOutcomes) {


### PR DESCRIPTION
## Summary

- **Phase 1 wait:** `waitForTabComplete` now matches on origin only, not `origin + pathname`. Strict pathname matching meant any Cloudflare/login redirect (still on `www.upwork.com`) never resolved, hitting the 60s timeout and surfacing as `Scrape failed: Tab load timeout` in the activity log + issue webhook payload. Phase 2's 10s captcha-marker polling still catches challenges, so this is safe.
- **chrome-error detection:** Reject early when `tab.url` or `changeInfo.url` is `chrome-error://chromewebdata/`. Eliminates the 60s hang on network failures and short-circuits the executeScript that produces Sentry **JAVASCRIPT-9Z** ("Frame with ID 0 is showing error page", 163 events). New ScrapeResult error message: `Chrome error page (network failure)`.
- **Single retry:** New `scrapeTargetWithRetry` retries once on Tab-load-timeout results with a 7s backoff. Wraps `scrapeTarget` only — `processTargetResult` still runs exactly once on the final result, so a retry can't double-count new jobs or double-fire webhooks.
- **Concurrency cap:** Replaced `Promise.all(activeTargets.map(...))` with an in-file `runWithConcurrency` limited to 2. Reduces simultaneous Upwork tabs (which compound Cloudflare bot signals) without serializing wall-clock time the way concurrency=1 would.

No new permissions required. No new dependencies.

Skipped #5 (bump 60s → 90s) from the handoff doc — strict-pathname was the actual cause; the cushion would hide regressions rather than fix any. Easy to add later if Sentry still shows timeouts post-deploy.

## Test plan

- [ ] Trigger a Cloudflare challenge on a target (don't auto-resolve) → activity log shows `Cloudflare verification required` within ~10s, not after 60s.
- [ ] Disable network mid-load → activity log shows `Chrome error page (network failure)`, no 60s hang.
- [ ] 4–5 active targets → at most 2 tabs open simultaneously; webhook delivery succeeds for all.
- [ ] Force-fail one target with a sketchy URL → log shows the retry message after 7s, second attempt resolves normally.
- [ ] Sentry watch (24h after deploy): **JAVASCRIPT-9Z** event rate drops ≥80%.

## Out of scope

- Sentry **JAVASCRIPT-9J** (3,335 events, "Failed to fetch (Promise.all idx 0)") — user webhook endpoints failing downstream. Separate fix: sample/throttle capture or gate by failure-count threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better detection and distinct reporting for Chrome network error pages during tab loads
  * Tab load synchronization now avoids false completions during redirects and error navigations
  * Added automatic retry for tab load timeouts

* **Performance**
  * Controlled concurrency for scraping tasks to improve stability and throughput
  * Post-scrape processing now runs sequentially to reduce contention and ensure reliable logging

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/richardadonnell/Upwork-Job-Scraper/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->